### PR TITLE
Use custom input component(s)

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -373,50 +373,40 @@ export default React.createClass({
       monthLabels={this.props.monthLabels}
       dateFormat={this.props.dateFormat} />;
 
+    let children;
+
     if (this.props.customInputComponent) {
-      const childrenWithProps = React.Children.map(this.props.children, (child) => {
+      children = React.Children.map(this.props.children, (child) => {
         React.cloneElement(child, {
           ...this.props,
         });
       });
-
-      return (
-        <InputGroup ref="inputGroup" bsClass={this.props.bsClass} bsSize={this.props.bsSize} id={this.props.id ? this.props.id + "_group" : null}>
-          <Overlay rootClose={true} onHide={this.handleHide} show={this.state.focused} container={() => ReactDOM.findDOMNode(this.refs.overlayContainer)} target={() => ReactDOM.findDOMNode(this.refs.input)} placement={this.props.calendarPlacement} delayHide={200}>
-            <Popover id="calendar" title={calendarHeader}>
-              <Calendar cellPadding={this.props.cellPadding} selectedDate={this.state.selectedDate} displayDate={this.state.displayDate} onChange={this.onChangeDate} dayLabels={this.props.dayLabels} />
-            </Popover>
-          </Overlay>
-          <div ref="overlayContainer" />
-          <input type="hidden" id={this.props.id} name={this.props.name} value={this.state.value || ''} />
-          <div>
-            {childrenWithProps}
-          </div>
-        </InputGroup>
-      );
     } else {
-      return (
-        <InputGroup ref="inputGroup" bsClass={this.props.bsClass} bsSize={this.props.bsSize} id={this.props.id ? this.props.id + "_group" : null}>
-          <Overlay rootClose={true} onHide={this.handleHide} show={this.state.focused} container={() => ReactDOM.findDOMNode(this.refs.overlayContainer)} target={() => ReactDOM.findDOMNode(this.refs.input)} placement={this.props.calendarPlacement} delayHide={200}>
-            <Popover id="calendar" title={calendarHeader}>
-              <Calendar cellPadding={this.props.cellPadding} selectedDate={this.state.selectedDate} displayDate={this.state.displayDate} onChange={this.onChangeDate} dayLabels={this.props.dayLabels} />
-            </Popover>
-          </Overlay>
-          <div ref="overlayContainer" />
-          <input type="hidden" id={this.props.id} name={this.props.name} value={this.state.value || ''} />
-          <FormControl
-            onKeyDown={this.handleKeyDown}
-            value={this.state.inputValue || ''}
-            ref="input"
-            type="text"
-            placeholder={this.state.focused ? this.props.dateFormat : this.state.placeholder}
-            onFocus={this.handleFocus}
-            onBlur={this.handleBlur}
-            onChange={this.handleInputChange}
-          />
-          <InputGroup.Addon onClick={this.clear} style={{cursor:this.state.inputValue ? "pointer" : "not-allowed"}}>{this.props.clearButtonElement}</InputGroup.Addon>
-        </InputGroup>
+      children = (
+        <FormControl
+          onKeyDown={this.handleKeyDown}
+          value={this.state.inputValue || ''}
+          ref="input"
+          type="text"
+          placeholder={this.state.focused ? this.props.dateFormat : this.state.placeholder}
+          onFocus={this.handleFocus}
+          onBlur={this.handleBlur}
+          onChange={this.handleInputChange}
+        />
       );
     }
+
+    return (
+      <InputGroup ref="inputGroup" bsClass={this.props.bsClass} bsSize={this.props.bsSize} id={this.props.id ? this.props.id + "_group" : null}>
+        <Overlay rootClose={true} onHide={this.handleHide} show={this.state.focused} container={() => ReactDOM.findDOMNode(this.refs.overlayContainer)} target={() => ReactDOM.findDOMNode(this.refs.input)} placement={this.props.calendarPlacement} delayHide={200}>
+          <Popover id="calendar" title={calendarHeader}>
+            <Calendar cellPadding={this.props.cellPadding} selectedDate={this.state.selectedDate} displayDate={this.state.displayDate} onChange={this.onChangeDate} dayLabels={this.props.dayLabels} />
+          </Popover>
+        </Overlay>
+        <div ref="overlayContainer" />
+        <input type="hidden" id={this.props.id} name={this.props.name} value={this.state.value || ''} />
+        {children}
+      </InputGroup>
+    );
   }
 });

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -121,7 +121,7 @@ export default React.createClass({
   propTypes: {
     value: React.PropTypes.string,
     cellPadding: React.PropTypes.string,
-    customInputComponent: React.PropTypes.optionalElement,
+    customInputComponent: React.PropTypes.bool,
     placeholder: React.PropTypes.string,
     dayLabels: React.PropTypes.array,
     monthLabels: React.PropTypes.array,
@@ -152,7 +152,7 @@ export default React.createClass({
                     'May', 'June', 'July', 'August', 'September',
                     'October', 'November', 'December'],
       clearButtonElement: "×",
-      customInputComponent: null,
+      customInputComponent: false,
       previousButtonElement: "<",
       nextButtonElement: ">",
       calendarPlacement: "bottom",
@@ -374,10 +374,25 @@ export default React.createClass({
       dateFormat={this.props.dateFormat} />;
 
     if (this.props.customInputComponent) {
+      const childrenWithProps = React.Children.map(this.props.children, (child) => {
+        React.cloneElement(child, {
+          ...this.props,
+        });
+      });
+
       return (
-        <div>
-          Hey a custom component
-        </div>
+        <InputGroup ref="inputGroup" bsClass={this.props.bsClass} bsSize={this.props.bsSize} id={this.props.id ? this.props.id + "_group" : null}>
+          <Overlay rootClose={true} onHide={this.handleHide} show={this.state.focused} container={() => ReactDOM.findDOMNode(this.refs.overlayContainer)} target={() => ReactDOM.findDOMNode(this.refs.input)} placement={this.props.calendarPlacement} delayHide={200}>
+            <Popover id="calendar" title={calendarHeader}>
+              <Calendar cellPadding={this.props.cellPadding} selectedDate={this.state.selectedDate} displayDate={this.state.displayDate} onChange={this.onChangeDate} dayLabels={this.props.dayLabels} />
+            </Popover>
+          </Overlay>
+          <div ref="overlayContainer" />
+          <input type="hidden" id={this.props.id} name={this.props.name} value={this.state.value || ''} />
+          <div>
+            {childrenWithProps}
+          </div>
+        </InputGroup>
       );
     } else {
       return (

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -121,6 +121,7 @@ export default React.createClass({
   propTypes: {
     value: React.PropTypes.string,
     cellPadding: React.PropTypes.string,
+    customInputComponent: React.PropTypes.optionalElement,
     placeholder: React.PropTypes.string,
     dayLabels: React.PropTypes.array,
     monthLabels: React.PropTypes.array,
@@ -151,6 +152,7 @@ export default React.createClass({
                     'May', 'June', 'July', 'August', 'September',
                     'October', 'November', 'December'],
       clearButtonElement: "×",
+      customInputComponent: null,
       previousButtonElement: "<",
       nextButtonElement: ">",
       calendarPlacement: "bottom",
@@ -370,25 +372,36 @@ export default React.createClass({
       onChange={this.onChangeMonth}
       monthLabels={this.props.monthLabels}
       dateFormat={this.props.dateFormat} />;
-    return <InputGroup ref="inputGroup" bsClass={this.props.bsClass} bsSize={this.props.bsSize} id={this.props.id ? this.props.id + "_group" : null}>
-      <Overlay rootClose={true} onHide={this.handleHide} show={this.state.focused} container={() => ReactDOM.findDOMNode(this.refs.overlayContainer)} target={() => ReactDOM.findDOMNode(this.refs.input)} placement={this.props.calendarPlacement} delayHide={200}>
-        <Popover id="calendar" title={calendarHeader}>
-          <Calendar cellPadding={this.props.cellPadding} selectedDate={this.state.selectedDate} displayDate={this.state.displayDate} onChange={this.onChangeDate} dayLabels={this.props.dayLabels} />
-        </Popover>
-      </Overlay>
-      <div ref="overlayContainer" />
-      <input type="hidden" id={this.props.id} name={this.props.name} value={this.state.value || ''} />
-      <FormControl
-        onKeyDown={this.handleKeyDown}
-        value={this.state.inputValue || ''}
-        ref="input"
-        type="text"
-        placeholder={this.state.focused ? this.props.dateFormat : this.state.placeholder}
-        onFocus={this.handleFocus}
-        onBlur={this.handleBlur}
-        onChange={this.handleInputChange}
-      />
-      <InputGroup.Addon onClick={this.clear} style={{cursor:this.state.inputValue ? "pointer" : "not-allowed"}}>{this.props.clearButtonElement}</InputGroup.Addon>
-    </InputGroup>;
+
+    if (this.props.customInputComponent) {
+      return (
+        <div>
+          Hey a custom component
+        </div>
+      );
+    } else {
+      return (
+        <InputGroup ref="inputGroup" bsClass={this.props.bsClass} bsSize={this.props.bsSize} id={this.props.id ? this.props.id + "_group" : null}>
+          <Overlay rootClose={true} onHide={this.handleHide} show={this.state.focused} container={() => ReactDOM.findDOMNode(this.refs.overlayContainer)} target={() => ReactDOM.findDOMNode(this.refs.input)} placement={this.props.calendarPlacement} delayHide={200}>
+            <Popover id="calendar" title={calendarHeader}>
+              <Calendar cellPadding={this.props.cellPadding} selectedDate={this.state.selectedDate} displayDate={this.state.displayDate} onChange={this.onChangeDate} dayLabels={this.props.dayLabels} />
+            </Popover>
+          </Overlay>
+          <div ref="overlayContainer" />
+          <input type="hidden" id={this.props.id} name={this.props.name} value={this.state.value || ''} />
+          <FormControl
+            onKeyDown={this.handleKeyDown}
+            value={this.state.inputValue || ''}
+            ref="input"
+            type="text"
+            placeholder={this.state.focused ? this.props.dateFormat : this.state.placeholder}
+            onFocus={this.handleFocus}
+            onBlur={this.handleBlur}
+            onChange={this.handleInputChange}
+          />
+          <InputGroup.Addon onClick={this.clear} style={{cursor:this.state.inputValue ? "pointer" : "not-allowed"}}>{this.props.clearButtonElement}</InputGroup.Addon>
+        </InputGroup>
+      );
+    }
   }
 });


### PR DESCRIPTION
- Added a customInputComponent prop (bool)
- If customInputComponent is true, then it will use `React.cloneElement` to pass in all the props to `this.props.children`.
- Then, with the children (three input fields) we can manipulate when/how the calendar is shown using `this.handleFocus` and `this.handleBlur`.
